### PR TITLE
S2E6 - Transformer validation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,7 @@ We follow a documentation-driven, test-first process.
     *   Explain the Why, What, and How of the changeset to the user and invite them to do a first-parse review
     *   Use `rake commit:review` to analyze changes.
     *   Use `rake commit:message` to generate a conventional commit message
-    *   Use the generated message to write a suitable commit message summarizing the story completion
+    *   Use the generated message and the "Why/What/How" to write a suitable PR description summarizing the story completion
 4.  **Document**: After implementation, update all relevant documentation (`README.md`, `goals.md`, etc.) and their history logs.
 
 ### Key Principles & Standards

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,22 @@ jobs:
       - name: Lint code for consistent style
         run: bin/rubocop -f github
 
+  validate_transformers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: mise.toml
+          bundler-cache: true
+
+      - name: Validate Transformers
+        run: bundle exec rake transformer:list transformer:validate
+
+
   test:
     runs-on: ubuntu-latest
 

--- a/.idea/transformer.iml
+++ b/.idea/transformer.iml
@@ -67,6 +67,7 @@
     <orderEntry type="library" scope="PROVIDED" name="faker (v3.5.2, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="fugit (v1.11.1, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="globalid (v1.2.1, mise: 3.4.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="hana (v1.3.7, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="hashdiff (v1.2.0, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="i18n (v1.14.7, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="importmap-rails (v2.1.0, mise: 3.4.4) [gem]" level="application" />
@@ -74,7 +75,7 @@
     <orderEntry type="library" scope="PROVIDED" name="irb (v1.15.2, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="jbuilder (v2.13.0, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="json (v2.12.2, mise: 3.4.4) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="json-schema (v2.8.1, mise: 3.4.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="json_schemer (v2.4.0, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="kamal (v2.7.0, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="language_server-protocol (v3.17.0.5, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="lint_roller (v1.1.0, mise: 3.4.4) [gem]" level="application" />
@@ -139,6 +140,7 @@
     <orderEntry type="library" scope="PROVIDED" name="securerandom (v0.4.1, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="selenium-webdriver (v4.34.0, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="shoulda-matchers (v6.5.0, mise: 3.4.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="simpleidn (v0.2.3, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="solid_cable (v3.0.11, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="solid_cache (v1.0.7, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="solid_queue (v1.1.5, mise: 3.4.4) [gem]" level="application" />

--- a/.idea/transformer.iml
+++ b/.idea/transformer.iml
@@ -74,6 +74,7 @@
     <orderEntry type="library" scope="PROVIDED" name="irb (v1.15.2, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="jbuilder (v2.13.0, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="json (v2.12.2, mise: 3.4.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="json-schema (v2.8.1, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="kamal (v2.7.0, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="language_server-protocol (v3.17.0.5, mise: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="lint_roller (v1.1.0, mise: 3.4.4) [gem]" level="application" />

--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,9 @@ group :development, :test do
 
   gem "factory_bot_rails", "~> 6.4"
   gem "faker", "~> 3.5"
+
+  # For validating YAML transformation files against a JSON Schema
+  gem "json_schemer", "~> 2.4"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hana (1.3.7)
     hashdiff (1.2.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
@@ -140,6 +141,11 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.12.2)
+    json_schemer (2.4.0)
+      bigdecimal
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
     kamal (2.7.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -331,6 +337,7 @@ GEM
       websocket (~> 1.0)
     shoulda-matchers (6.5.0)
       activesupport (>= 5.2.0)
+    simpleidn (0.2.3)
     solid_cable (3.0.11)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -425,6 +432,7 @@ DEPENDENCIES
   faker (~> 3.5)
   importmap-rails
   jbuilder
+  json_schemer (~> 2.4)
   kamal
   liquid (~> 5.4)
   propshaft

--- a/docs/schemas/transformation_schema.json
+++ b/docs/schemas/transformation_schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "YAML Transformation Schema",
+  "description": "Schema for validating Transformer application YAML configuration files.",
+  "type": "object",
+  "required": ["name", "description", "version", "transformations"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Unique identifier for this transformation."
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable description of what the transformation does."
+    },
+    "version": {
+      "type": "string",
+      "description": "Semantic version for the transformation."
+    },
+    "transformations": {
+      "type": "array",
+      "description": "Sequential list of transformation steps.",
+      "items": {
+        "type": "object",
+        "required": ["type", "config"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["regex_replace", "base64_encode", "base64_decode", "function_based"]
+          },
+          "config": {
+            "type": "object"
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/goals.md
+++ b/goals.md
@@ -147,11 +147,11 @@ A tool for common string transformations including:
 **Completed**: Complete YAML sample transformations library with practical real-world examples including K8s Secret decoding, log processing, and pattern-based line filtering.
 
 ### Story 2.6: Transformation Validation & Tooling
-**Status**: 📋 Planning
-- [ ] Create YAML schema validation using JSON Schema
-- [ ] Add YAML syntax error reporting with line numbers
-- [ ] Build `rake transformer:validate` task for testing YAML files
-- [ ] Add `rake transformer:list` to show available transformations
+**Status**: ✅ Complete
+- [x] Create YAML schema validation using JSON Schema
+- [x] Add YAML syntax error reporting with line numbers
+- [x] Build `rake transformer:validate` task for testing YAML files
+- [x] Add `rake transformer:list` to show available transformations
 
 ### Story 2.7: Persistence Layer
 **Status**: Not Started

--- a/lib/tasks/transformer.rake
+++ b/lib/tasks/transformer.rake
@@ -2,50 +2,7 @@
 
 require "json_schemer"
 
-# The Transformer module provides a namespace for all transformation-related logic.
-module Transformer
-  # The Validator class is responsible for validating YAML transformation files.
-  class Validator
-    def self.validate_all
-      schema_path = Rails.root.join("docs", "schemas", "transformation_schema.json")
-      schema = Pathname.new(schema_path)
-      schemer = JSONSchemer.schema(schema)
-
-      files = Dir.glob(Rails.root.join("config", "transformations", "*.yml"))
-      errors = []
-
-      files.each do |file_path|
-        errors.concat(validate_file(file_path, schemer))
-      end
-
-      if errors.empty?
-        puts "All transformation files are valid."
-        true
-      else
-        puts errors.join("\n")
-        false
-      end
-    end
-
-    def self.validate_file(file_path, schemer)
-      errors = []
-      begin
-        file_content = File.read(file_path)
-        data = YAML.safe_load(file_content, permitted_classes: [ Symbol ], aliases: true)
-        validation_errors = schemer.validate(data).to_a
-        return [] if validation_errors.empty?
-
-        errors << "ERROR: Schema validation failed for #{file_path}:"
-        errors.concat(validation_errors.map do |e|
-          "  - Error: `#{e['type']}` - `#{e['error']}` at `#{e['data_pointer']}`"
-        end)
-      rescue Psych::SyntaxError => e
-        errors << "ERROR: Invalid YAML syntax in #{file_path}: #{e.message}"
-      end
-      errors
-    end
-  end
-end
+require_relative "../transformer/validator"
 
 namespace :transformer do
   desc "Lists all available YAML transformations"

--- a/lib/tasks/transformer.rake
+++ b/lib/tasks/transformer.rake
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'json_schemer'
+require "json_schemer"
 
 namespace :transformer do
   desc "Lists all available YAML transformations"
   task list: :environment do
     puts "Available Transformations:"
-    path = Rails.root.join('config', 'transformations', '*.yml')
+    path = Rails.root.join("config", "transformations", "*.yml")
     Dir.glob(path).each do |file|
       puts "  - #{File.basename(file, '.yml')}"
     end
@@ -14,17 +14,17 @@ namespace :transformer do
 
   desc "Validates all YAML transformation files against the schema"
   task validate: :environment do
-    schema_path = Rails.root.join('docs', 'schemas', 'transformation_schema.json')
+    schema_path = Rails.root.join("docs", "schemas", "transformation_schema.json")
     schema = Pathname.new(schema_path)
     schemer = JSONSchemer.schema(schema)
 
-    files = Dir.glob(Rails.root.join('config', 'transformations', '*.yml'))
+    files = Dir.glob(Rails.root.join("config", "transformations", "*.yml"))
     errors = []
 
     files.each do |file_path|
       begin
         file_content = File.read(file_path)
-        data = YAML.safe_load(file_content, permitted_classes: [Symbol], aliases: true)
+        data = YAML.safe_load(file_content, permitted_classes: [ Symbol ], aliases: true)
         validation_errors = schemer.validate(data).to_a
         next if validation_errors.empty?
 

--- a/lib/tasks/transformer.rake
+++ b/lib/tasks/transformer.rake
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'json_schemer'
+
+namespace :transformer do
+  desc "Lists all available YAML transformations"
+  task list: :environment do
+    puts "Available Transformations:"
+    path = Rails.root.join('config', 'transformations', '*.yml')
+    Dir.glob(path).each do |file|
+      puts "  - #{File.basename(file, '.yml')}"
+    end
+  end
+
+  desc "Validates all YAML transformation files against the schema"
+  task validate: :environment do
+    schema_path = Rails.root.join('docs', 'schemas', 'transformation_schema.json')
+    schema = Pathname.new(schema_path)
+    schemer = JSONSchemer.schema(schema)
+
+    files = Dir.glob(Rails.root.join('config', 'transformations', '*.yml'))
+    errors = []
+
+    files.each do |file_path|
+      begin
+        file_content = File.read(file_path)
+        data = YAML.safe_load(file_content, permitted_classes: [Symbol], aliases: true)
+        validation_errors = schemer.validate(data).to_a
+        next if validation_errors.empty?
+
+        errors << "ERROR: Schema validation failed for #{file_path}:"
+        # Format the errors to be more readable
+        errors.concat(validation_errors.map do |e|
+          "  - Error: `#{e['type']}` - `#{e['error']}` at `#{e['data_pointer']}`"
+        end)
+      rescue Psych::SyntaxError => e
+        errors << "ERROR: Invalid YAML syntax in #{file_path}: #{e.message}"
+      end
+    end
+
+    if errors.empty?
+      puts "All transformation files are valid."
+    else
+      puts errors.join("\n")
+      exit 1 # Fail the rake task if there are errors
+    end
+  end
+end

--- a/lib/tasks/transformer.rake
+++ b/lib/tasks/transformer.rake
@@ -41,8 +41,7 @@ namespace :transformer do
     if errors.empty?
       puts "All transformation files are valid."
     else
-      puts errors.join("\n")
-      exit 1 # Fail the rake task if there are errors
+      abort(errors.join("\n")) # Fail the rake task if there are errors
     end
   end
 end

--- a/lib/transformer/validator.rb
+++ b/lib/transformer/validator.rb
@@ -46,19 +46,3 @@ module Transformer
     end
   end
 end
-
-namespace :transformer do
-  desc "Lists all available YAML transformations"
-  task list: :environment do
-    puts "Available Transformations:"
-    path = Rails.root.join("config", "transformations", "*.yml")
-    Dir.glob(path).each do |file|
-      puts "  - #{File.basename(file, '.yml')}"
-    end
-  end
-
-  desc "Validates all YAML transformation files against the schema"
-  task validate: :environment do
-    exit 1 unless Transformer::Validator.validate_all
-  end
-end

--- a/spec/lib/transformer/validator_spec.rb
+++ b/spec/lib/transformer/validator_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "transformer/validator"
+
+RSpec.describe Transformer::Validator do
+  describe ".validate_all" do
+    # This method is complex to test in isolation as it interacts with the file system and Rails.
+    # Its behavior is indirectly tested via the `transformer:validate` rake task spec.
+    # We will focus on testing the `validate_file` method directly.
+  end
+
+  describe ".validate_file" do
+    let(:schema_path) { Rails.root.join("docs", "schemas", "transformation_schema.json") }
+    let(:schema_content) { File.read(schema_path) }
+    let(:schemer) { JSONSchemer.schema(Pathname.new(schema_path)) }
+
+    before do
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with(schema_path.to_s).and_return(schema_content)
+    end
+
+    it "returns an empty array for a valid file" do
+      valid_yaml = {
+        "name" => "valid_transform",
+        "description" => "A valid transformation",
+        "version" => "1.0",
+        "transformations" => [
+          {
+            "type" => "regex_replace",
+            "config" => { "pattern" => "a", "replacement" => "b" }
+          }
+        ]
+      }.to_yaml
+      allow(File).to receive(:read).with("/path/to/valid.yml").and_return(valid_yaml)
+
+      expect(described_class.validate_file("/path/to/valid.yml", schemer)).to be_empty
+    end
+
+    it "returns a syntax error for an invalid YAML file" do
+      invalid_yaml = "name: 'invalid\ndescription: 'bad syntax'"
+      allow(File).to receive(:read).with("/path/to/invalid_syntax.yml").and_return(invalid_yaml)
+
+      errors = described_class.validate_file("/path/to/invalid_syntax.yml", schemer)
+      expect(errors.first).to include("ERROR: Invalid YAML syntax in /path/to/invalid_syntax.yml")
+    end
+
+    it "returns a schema error for a file with an invalid schema" do
+      invalid_schema_yaml = {
+        "name" => "invalid_schema",
+        "description" => "Missing version and transformations"
+      }.to_yaml
+      allow(File).to receive(:read).with("/path/to/invalid_schema.yml").and_return(invalid_schema_yaml)
+
+      errors = described_class.validate_file("/path/to/invalid_schema.yml", schemer)
+      expect(errors.first).to eq("ERROR: Schema validation failed for /path/to/invalid_schema.yml:")
+      expect(errors.last).to include("missing required properties: version, transformations")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -96,6 +96,11 @@ RSpec.configure do |config|
     name = example.metadata[:full_description].split(/\s+/, 2).join("/").underscore.gsub(/[^\w\/]+/, "_")
     VCR.use_cassette(name) { example.call }
   end
+
+  config.before(:suite) do
+    # Load the Rakefile and tasks
+    Rails.application.load_tasks
+  end
 end
 
 # Configure VCR

--- a/spec/tasks/commit_validation_spec.rb
+++ b/spec/tasks/commit_validation_spec.rb
@@ -6,11 +6,11 @@ require 'rake'
 RSpec.describe 'Commit Validation Rake Tasks', type: :task do
   # Helper to suppress stdout for a block of code
   def with_suppressed_stdout
-    original_stdout = $stdout.clone
-    $stdout.reopen(File.new('/dev/null', 'w'))
+    original_stdout = $stdout
+    $stdout = StringIO.new
     yield
   ensure
-    $stdout.reopen(original_stdout)
+    $stdout = original_stdout
   end
 
   before do

--- a/spec/tasks/commit_validation_spec.rb
+++ b/spec/tasks/commit_validation_spec.rb
@@ -4,6 +4,15 @@ require 'rails_helper'
 require 'rake'
 
 RSpec.describe 'Commit Validation Rake Tasks', type: :task do
+  # Helper to suppress stdout for a block of code
+  def with_suppressed_stdout
+    original_stdout = $stdout.clone
+    $stdout.reopen(File.new('/dev/null', 'w'))
+    yield
+  ensure
+    $stdout.reopen(original_stdout)
+  end
+
   before do
     Rake::Task['commit:review'].reenable
     Rake::Task['commit:message'].reenable
@@ -19,7 +28,9 @@ RSpec.describe 'Commit Validation Rake Tasks', type: :task do
         double('reviewer', analyze_changes: ReviewResult.no_changes)
       )
 
-      expect { Rake::Task['commit:review'].invoke }.not_to raise_error
+      with_suppressed_stdout do
+        expect { Rake::Task['commit:review'].invoke }.not_to raise_error
+      end
     end
   end
 
@@ -33,7 +44,9 @@ RSpec.describe 'Commit Validation Rake Tasks', type: :task do
         double('reviewer', generate_commit_message: 'feat: add new feature')
       )
 
-      expect { Rake::Task['commit:message'].invoke }.not_to raise_error
+      with_suppressed_stdout do
+        expect { Rake::Task['commit:message'].invoke }.not_to raise_error
+      end
     end
   end
 end

--- a/spec/tasks/commit_validation_spec.rb
+++ b/spec/tasks/commit_validation_spec.rb
@@ -3,8 +3,6 @@
 require 'rails_helper'
 require 'rake'
 
-Rails.application.load_tasks
-
 RSpec.describe 'Commit Validation Rake Tasks', type: :task do
   before do
     Rake::Task['commit:review'].reenable

--- a/spec/tasks/transformer_spec.rb
+++ b/spec/tasks/transformer_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'transformer rake tasks', type: :task do
           ]
         }.to_yaml
 
-        allow(Dir).to receive(:glob).with(Rails.root.join('config', 'transformations', '*.yml')).and_return(['/path/to/valid.yml'])
+        allow(Dir).to receive(:glob).with(Rails.root.join('config', 'transformations', '*.yml')).and_return([ '/path/to/valid.yml' ])
         allow(File).to receive(:read).with('/path/to/valid.yml').and_return(valid_yaml)
 
         expect { Rake::Task['transformer:validate'].invoke }.to output(/All transformation files are valid./).to_stdout
@@ -64,7 +64,7 @@ RSpec.describe 'transformer rake tasks', type: :task do
     context 'with a file having invalid syntax' do
       it 'prints a syntax error message' do
         invalid_yaml = "name: 'invalid\ndescription: 'bad syntax'"
-        allow(Dir).to receive(:glob).with(Rails.root.join('config', 'transformations', '*.yml')).and_return(['/path/to/invalid_syntax.yml'])
+        allow(Dir).to receive(:glob).with(Rails.root.join('config', 'transformations', '*.yml')).and_return([ '/path/to/invalid_syntax.yml' ])
         allow(File).to receive(:read).with('/path/to/invalid_syntax.yml').and_return(invalid_yaml)
 
         expect { Rake::Task['transformer:validate'].invoke }.to output(/ERROR: Invalid YAML syntax in/).to_stdout
@@ -78,7 +78,7 @@ RSpec.describe 'transformer rake tasks', type: :task do
           'description' => 'Missing version and transformations'
         }.to_yaml
 
-        allow(Dir).to receive(:glob).with(Rails.root.join('config', 'transformations', '*.yml')).and_return(['/path/to/invalid_schema.yml'])
+        allow(Dir).to receive(:glob).with(Rails.root.join('config', 'transformations', '*.yml')).and_return([ '/path/to/invalid_schema.yml' ])
         allow(File).to receive(:read).with('/path/to/invalid_schema.yml').and_return(invalid_schema_yaml)
 
         # The new gem provides more specific error messages

--- a/spec/tasks/transformer_spec.rb
+++ b/spec/tasks/transformer_spec.rb
@@ -4,11 +4,6 @@ require 'rails_helper'
 require 'rake'
 
 RSpec.describe 'transformer rake tasks', type: :task do
-  # Load the Rakefile and tasks
-  before(:all) do
-    Rails.application.load_tasks
-  end
-
   # Re-enable the task before each run so it can be invoked multiple times
   before(:each) do
     Rake::Task['transformer:list'].reenable

--- a/spec/tasks/transformer_spec.rb
+++ b/spec/tasks/transformer_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'transformer rake tasks', type: :task do
+  # Load the Rakefile and tasks
+  before(:all) do
+    Rails.application.load_tasks
+  end
+
+  # Re-enable the task before each run so it can be invoked multiple times
+  before(:each) do
+    Rake::Task['transformer:list'].reenable
+    Rake::Task['transformer:validate'].reenable
+  end
+
+  describe 'transformer:list' do
+    it 'prints a list of available transformations' do
+      # Mock Dir.glob to return a predictable list of files
+      allow(Dir).to receive(:glob).with(Rails.root.join('config', 'transformations', '*.yml')).and_return([
+        Rails.root.join('config', 'transformations', 'first_transform.yml').to_s,
+        Rails.root.join('config', 'transformations', 'second_transform.yml').to_s
+      ])
+
+      # Capture stdout and run the task
+      expect { Rake::Task['transformer:list'].invoke }.to output(
+        /Available Transformations:.*first_transform.*second_transform/m
+      ).to_stdout
+    end
+  end
+
+  describe 'transformer:validate' do
+    let(:schema_path) { Rails.root.join('docs', 'schemas', 'transformation_schema.json') }
+    let(:schema) { File.read(schema_path) }
+
+    before do
+      # Stub the read for the transformation schema
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with(schema_path.to_s).and_return(schema)
+    end
+
+    context 'with valid transformation files' do
+      it 'prints a success message' do
+        valid_yaml = {
+          'name' => 'valid_transform',
+          'description' => 'A valid transformation',
+          'version' => '1.0',
+          'transformations' => [
+            {
+              'type' => 'regex_replace',
+              'config' => { 'pattern' => 'a', 'replacement' => 'b' }
+            }
+          ]
+        }.to_yaml
+
+        allow(Dir).to receive(:glob).with(Rails.root.join('config', 'transformations', '*.yml')).and_return(['/path/to/valid.yml'])
+        allow(File).to receive(:read).with('/path/to/valid.yml').and_return(valid_yaml)
+
+        expect { Rake::Task['transformer:validate'].invoke }.to output(/All transformation files are valid./).to_stdout
+      end
+    end
+
+    context 'with a file having invalid syntax' do
+      it 'prints a syntax error message' do
+        invalid_yaml = "name: 'invalid\ndescription: 'bad syntax'"
+        allow(Dir).to receive(:glob).with(Rails.root.join('config', 'transformations', '*.yml')).and_return(['/path/to/invalid_syntax.yml'])
+        allow(File).to receive(:read).with('/path/to/invalid_syntax.yml').and_return(invalid_yaml)
+
+        expect { Rake::Task['transformer:validate'].invoke }.to output(/ERROR: Invalid YAML syntax in/).to_stdout
+      end
+    end
+
+    context 'with a file having invalid schema' do
+      it 'prints a schema error message' do
+        invalid_schema_yaml = {
+          'name' => 'invalid_schema',
+          'description' => 'Missing version and transformations'
+        }.to_yaml
+
+        allow(Dir).to receive(:glob).with(Rails.root.join('config', 'transformations', '*.yml')).and_return(['/path/to/invalid_schema.yml'])
+        allow(File).to receive(:read).with('/path/to/invalid_schema.yml').and_return(invalid_schema_yaml)
+
+        # The new gem provides more specific error messages
+        expect { Rake::Task['transformer:validate'].invoke }.to output(/ERROR: Schema validation failed for .*invalid_schema.yml.*required.*version.*transformations/m).to_stdout
+      end
+    end
+  end
+end


### PR DESCRIPTION
feat(validation): Implement YAML transformation validation and tooling

This commit completes Story 2.6 by introducing a comprehensive suite of tools for validating and managing YAML transformation files.

**Why**: To ensure the reliability and correctness of our YAML-based transformations, we need robust validation against a defined schema and clear error reporting. This tooling is essential for developers creating and maintaining transformations.

**What**:
- **`rake transformer:validate`**: A new rake task that validates all `.yml` files in `config/transformations/` against the official `transformation_schema.json`. It checks for both YAML syntax errors and schema compliance.
- **`rake transformer:list`**: A utility task to list all available transformations.
- **Schema Validation**: Replaced the `json-schema` gem with the more modern `json_schemer` to provide reliable, offline-first schema validation without network-related test failures.
- **Error Reporting**: The validation task provides clear, actionable error messages for both syntax and schema violations.

**How**:
- The `transformer:validate` task now uses the `json_schemer` gem to load the schema and validate each transformation file.
- The implementation was refactored to use the correct `JSONSchemer.schema(path).validate(data)` API, resolving all previous `NoMethodError` issues.
- RSpec tests were updated to provide full coverage for the new validation logic, including success cases, syntax errors, and schema violations.